### PR TITLE
 Enhance use-outside-click.ts Hook with Strict Typing for Events and Callback.

### DIFF
--- a/src/app/use-outside-click.ts
+++ b/src/app/use-outside-click.ts
@@ -2,11 +2,11 @@ import React, { useEffect } from "react";
 
 export const useOutsideClick = (
   ref: React.RefObject<HTMLDivElement>,
-  callback: Function
+  callback: (event: MouseEvent | TouchEvent) => void
 ) => {
   useEffect(() => {
-    const listener = (event: any) => {
-      if (!ref.current || ref.current.contains(event.target)) {
+    const listener = (event: MouseEvent | TouchEvent) => {
+      if (!ref.current || ref.current.contains(event.target as Node)) {
         return;
       }
       callback(event);


### PR DESCRIPTION
Changes that i have made to the code are as follows:

1. Typed callback and event: I replaced the `any` type with `MouseEvent | TouchEvent` for the event and provided a more specific type for the `callback` function.

2. event.target as Node: Since `event.target` is of type `EventTarget`, which may not directly contain DOM manipulation methods, casting it to Node ensures the `contains()` method is correctly interpreted by TypeScript.