### PR TITLE
Image component dimension updation in PolaroidStack.tsx

### DIFF
--- a/src/custom_components/PolaroidStack.tsx
+++ b/src/custom_components/PolaroidStack.tsx
@@ -13,14 +13,14 @@ const Polaroid: React.FC<PolaroidProps> = ({ src, alt, rotation = 0 }) => (
     style={{
       transform: `rotate(${rotation}deg)`,
       width: "250px",
-      height: "300px",
+      height: "280px", // Adjusted to match the image height
     }}
   >
     <Image
       src={src}
       alt={alt}
-      width={280}
-      height={280}
+      width={250} // Adjusted to match the container width
+      height={250} // Adjusted to match the container height
       style={{ objectFit: "cover" }}
     />
     <div className="mt-4 text-center text-normal font-medium">{alt}</div>


### PR DESCRIPTION
1. **Image component dimensions**: The `Image` component from Next.js is using `width={280}` and `height={280}`, which exceeds the parent container size (`width: "250px"`). This will stretch the image beyond the container. To fix this:
   - Either reduce the `width` and `height` of the `Image` component to fit within the `250px` container.
   - Or, adjust the container's width and height to match the image dimensions.

